### PR TITLE
CMake is now used to build the executable Frometon-Engine !

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
-# Executable files
-*.o
+# Build files
+bin/*
+
+# Vim and editors
+*.swp
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1)
+project(Frometon-Engine)
+
+find_package(OpenGL REQUIRED)
+find_package(GLUT REQUIRED)
+add_executable(Frometon-Engine src/main.cpp)
+find_package(PkgConfig REQUIRED)
+pkg_search_module(GLFW REQUIRED glfw3)
+
+
+include_directories( ${OPENGL_INCLUDE_DIRS}  ${GLUT_INCLUDE_DIRS} ${GLFW_INCLUDE_DIRS})
+target_link_libraries(Frometon-Engine ${OPENGL_LIBRARIES} ${GLUT_LIBRARY} ${GLFW_LIBRARIES})

--- a/compile.sh
+++ b/compile.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-g++ src/main.cpp -o bin/main.o -lGL -lGLU -lglfw -lX11 -lXxf86vm -lXrandr -lpthread -lXi


### PR DESCRIPTION
The previous bash file is now deleted ! 👺

.gitignore now ignore:
- *swp files made by Atom or vim
- the whole bin folder (previously only *.o)